### PR TITLE
Fix empty Config view caused by null authentication field

### DIFF
--- a/Common/Model/ConfigModel.swift
+++ b/Common/Model/ConfigModel.swift
@@ -10,7 +10,7 @@ import Combine
 
 struct ConfigData: Decodable {
     var allowLan:Bool?
-    var authentication:[String]
+    var authentication:[String]?
     var bindAddress: String?
     var ipv6:Bool?
     var logLevel: String?
@@ -108,7 +108,7 @@ class ConfigModel: ObservableObject {
             receiveValue: { [weak self] config in
                 var configData = ConfigDataModel()
                 configData.allowLan = config.allowLan ?? false
-                configData.authentication = config.authentication
+                configData.authentication = config.authentication ?? []
                 configData.bindAddress = config.bindAddress ?? ""
                 configData.ipv6 = config.ipv6 ?? false
                 if let mode = config.mode {


### PR DESCRIPTION
## Summary
- The Clash REST API returns `"authentication": null` when no auth list is configured (verified against a live server at `192.168.111.1:9191`).
- `ConfigData.authentication` was declared as a non-optional `[String]`, so decoding that `null` value threw and silently failed the entire `/configs` decode.
- As a result, `receiveValue` never ran, `configData.initialized` stayed `false`, and the 配置 (Config) view rendered permanently empty.

## Fix
- Made `ConfigData.authentication` optional (`[String]?`).
- Default to `[]` when mapping into `ConfigDataModel` if the field is absent.

## Test plan
- [x] Verified the real API response includes `"authentication": null` via `curl`.
- [ ] Build and run the app, connect to a Clash server, and confirm the Config view now populates.